### PR TITLE
Adding parameterized control to show description at top of visualization

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -24,9 +24,12 @@ h6 {
     margin-right: auto;
     margin-left: auto;
 }
+.viz-description {
+	display: none;
+	padding-bottom: 20px;
+}
 #map {
 	height: 500px;
-	margin-top: 20px;
 }
 #mapLegend {
 	background-color: rgba(255, 255, 255, 0.9);

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <body>
         <div class="viz-container">
             <div class="row">
-                <div class="col-md-12">
+                <div class="col-md-12 viz-description">
                     <p>The Moving Energy Initiative has developed a model offering the first estimates of the scale and cost of energy use and CO2 emissions among the households of persons of concern to UNHCR worldwide. This is a highly simplified model of a complex system and is intended as a learning document for the international community - to be built on and improved over time. The model gives indicative estimates of values and should not be viewed as a comprehensive picture, but rather as a starting point for further research.</p>
                     <p>Where evidence exists, we invite practitioners and those working on the ground to submit their own data and observations to improve this picture. To do so, use the feedback buttons in the country specific pop-ups. A member of our team will get in touch to discuss and integrate findings where concrete knowledge and/or evidence can be demonstrated.</p>
                 </div>

--- a/js/site.js
+++ b/js/site.js
@@ -402,6 +402,16 @@ function getCountryNames(datasets) {
     return output;
 }
 
+function getParamValue(paramName) {
+    var url = window.location.search.substring(1); 
+    var qArray = url.split('&'); 
+    for (var i=0; i<qArray.length; i++) {
+        var pArr = qArray[i].split('='); 
+        if (pArr[0] == paramName) 
+            return pArr[1]; 
+    }
+}
+
 let numFormat = function(d){return d3.format('.2f')(d)};
 let numFormat2 = function(d){return d3.format('.3f')(d)};
 let numFormatSF = function(d){return d3.format('.2g')(d)};
@@ -455,6 +465,10 @@ $.when(datasetCall, nonCampCall,largeCampCall,geomCall,popCall).then(function(da
     countryNames = getCountryNames([nonCampData, largeCampData]);
     cookingPerCountry = getCookingPerCountry(countryNames, nonCampData, largeCampData);
     datasetDate = datasetArgs[0].result.dataset_date
+
+    //check value of viz description in url parameter -- hide by default
+    var showDescription = getParamValue('showDescription');
+    if (showDescription=='true') $('.viz-description').show();
 
     countryOverview = function(iso3) {
         let lighting = {};


### PR DESCRIPTION
@mcarans This update looks for a parameter called 'showDescription' to control whether the visualization description is shown or not -- it is hidden by default. If you want to see the description, you would pass the parameter like this:
<iframe id="embedded-viz-iframe" src="https://data.humdata.org/visualization/mei-refugee-energy/?showDescription=true" frameborder="0" width="1200" height="880"></iframe>

Please merge this when you are ready. This parameter would need to be added to the org page. Let me know if there are any issues!